### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 A Model Context Protocol (MCP) server that enables AI assistants to interact with the ChatGPT desktop app on macOS.
 
+<a href="https://glama.ai/mcp/servers/@xncbf/chatgpt-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xncbf/chatgpt-mcp/badge" alt="ChatGPT Server MCP server" />
+</a>
 
-
-
-https://github.com/user-attachments/assets/a30c9b34-cdbe-4c0e-a0b0-33eb5054db5c
-
-
+![Screenshot](https://github.com/user-attachments/assets/a30c9b34-cdbe-4c0e-a0b0-33eb5054db5c)
 
 ## Language Support
 


### PR DESCRIPTION
This PR adds a badge for the [ChatGPT MCP Server](https://glama.ai/mcp/servers/@xncbf/chatgpt-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@xncbf/chatgpt-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xncbf/chatgpt-mcp/badge" alt="ChatGPT Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.